### PR TITLE
support/issues/1239

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,15 +5,15 @@ approvers:
   - durandom
   - goern
   - harshad16
-  - hpdempsey
   - rbo
   - schwesig
   - tumido
+  - quaid
 
 emeritus_approvers:
   - cooktheryan
   - gregory-pereira
-  - quaid
+  - hpdempsey
 
 reviewers:
   - codificat

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -191,10 +191,12 @@ orgs:
         description: Prometheus Alertmanager webhook receiver that creates GitHub issues from alerts
         has_issues: false
         has_projects: true
+        has_wiki: false
       alerts:
         default_branch: main
         description: Bots posting alerts from our clusters
         has_projects: false
+        has_wiki: false
       apps:
         description: Operate-first application manifests
         has_projects: false
@@ -222,6 +224,7 @@ orgs:
         default_branch: main
         description: Git Hub organization configuration
         has_projects: false
+        has_wiki: false
       community:
         default_branch: main
         has_projects: false

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -437,7 +437,6 @@ orgs:
       SourceOps:
         description: This is our SourceOps team, they keep the source fresh.
         maintainers:
-          - sesheta
           - op1st
         privacy: closed
         repos:

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -1,17 +1,10 @@
 orgs:
   operate-first:
     admins:
-      - cooktheryan
       - durandom
       - goern
-      - Gregory-Pereira
-      - HumairAK
       - quaid
-      - redmikhail
-      - ryanaslett
       - schwesig
-      - sesheta
-      - tumido
     billing_email: mhild@redhat.com
     company: ""
     default_repository_permission: read
@@ -54,6 +47,7 @@ orgs:
       - christusa
       - codificat
       - coghlanRH
+      - cooktheryan
       - DanNiESh
       - dastergon
       - dave-tucker
@@ -70,12 +64,14 @@ orgs:
       - Gaikanomer9
       - Gkrumbach07
       - gmfrasca
+      - Gregory-Pereira
       - gshahrouzi
       - harshad16
       - hbrock25
       - hemajv
       - hlipsig
       - hpdempsey
+      - HumairAK
       - husky-parul
       - ipolonsk
       - jacobarcarola
@@ -88,6 +84,7 @@ orgs:
       - khansaad
       - knikolla
       - KPostOffice
+      - krisv
       - krisv
       - larsks
       - laxmisravyarudraraju
@@ -125,6 +122,7 @@ orgs:
       - ravitejamanepalli
       - rbadagandi
       - rbo
+      - redmikhail
       - revit13
       - rh-tmichels
       - rimolive
@@ -133,6 +131,7 @@ orgs:
       - RobotSail
       - roytman
       - russellb
+      - ryanaslett
       - rynofinn
       - saadullah01
       - sallyom
@@ -156,12 +155,14 @@ orgs:
       - timflannagan
       - tmicheli
       - TomB1111
+      - TomB1111
       - travier
       - traytorous
       - TreeinRandomForest
       - trujillm
       - tsisodia10
       - tssala23
+      - tumido
       - uffish
       - VannTen
       - veniceofcode
@@ -169,8 +170,6 @@ orgs:
       - vpavlin
       - vrutkovs
       - zaoxing
-      - krisv
-      - TomB1111
     members_can_create_repositories: false
     name: Operate First
     repos:

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -5,6 +5,7 @@ orgs:
       - goern
       - quaid
       - schwesig
+      - sesheta
     billing_email: mhild@redhat.com
     company: ""
     default_repository_permission: read


### PR DESCRIPTION
- feat: disable some wikis
- refactor(github): moved all the (now) none-admin to members section

closes https://github.com/operate-first/support/issues/1239
